### PR TITLE
fix '?' --> filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
   try {
     var result = UglifyJS.minify(src, merge(opts, this.options));
   } catch(e) {
-    e.filename = (!e.filename || e.filename === '?') ? relativePath : e.filename;
+    e.filename = relativePath;
     throw e;
   }
 

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
     var result = UglifyJS.minify(src, merge(opts, this.options));
   } catch(e) {
     e.filename = e.filename || relativePath;
+    e.filename = (e.filename === '?') ? relativePath : e.filename;
     throw e;
   }
 

--- a/index.js
+++ b/index.js
@@ -98,8 +98,7 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
   try {
     var result = UglifyJS.minify(src, merge(opts, this.options));
   } catch(e) {
-    e.filename = e.filename || relativePath;
-    e.filename = (e.filename === '?') ? relativePath : e.filename;
+    e.filename = (!e.filename || e.filename === '?') ? relativePath : e.filename;
     throw e;
   }
 


### PR DESCRIPTION
'?' is still considered a string, so we will not see the actual filename printed on the console with the error

Hence this change 