### PR TITLE
minifyJS now accepts exclude: [] array of globs to skip minification on

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "broccoli-writer": "^0.1.1",
     "lodash-node": "^2.4.1",
+    "minimatch": "^2.0.10",
     "mkdirp": "^0.5.0",
     "source-map-url": "^0.3.0",
     "symlink-or-copy": "^1.0.1",
@@ -24,5 +25,4 @@
     "mocha": "^2.0.1",
     "rsvp": "^3.0.14"
   }
-
 }


### PR DESCRIPTION
- minifyJS object now accepts an exclude: [] parameter of glob strings to exclude
- added dependency minimatch
- added check against sourceMapConfig.minifyJS.exclude to short circuit processFile and skip minification

one thing to note is that the exclude: [] param to minifyJS requires listing paths with assets/ (ie assets/tinymce, etc..) this is distinct from fingerprint.exclude which seems to assume you are already in assets.

the existing relativePath var had assets/ already on it, so I opted to leave it this way