### PR TITLE
Log and warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var symlinkOrCopy = require('symlink-or-copy');
 var mkdirp = require('mkdirp');
 var srcURL = require('source-map-url');
 var MatcherCollection = require('matcher-collection');
+var debug = require('debug')('broccoli-uglify-sourcemap');
 
 module.exports = UglifyWriter;
 
@@ -115,7 +116,18 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
   }
 
   try {
+    var start = new Date();
+    debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
     var result = UglifyJS.minify(src, merge(opts, this.options));
+    var end = new Date();
+    var total = end - start;
+    debug('[finsihed]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
+
+    if (total > 20000) {
+      console.warn('[WARN] `' + relativePath + '` took: ' + total + 'ms (more then 20,000ms)');
+    }
+
+
   } catch(e) {
     e.filename = relativePath;
     throw e;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
+    "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "matcher-collection": "^1.0.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
this warns after the build, which may not indicate why something is slow until too late.

It might be good to warn, before building. Maybe do to some file-size limit threshold. I am unclear what the threshold may be.

@SlexAxton ideas? If you have some, I would love a contribution to help improve this further.