### PR TITLE
[DOCFIX] Update the README.md to reflect the real package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ maintaining sourcemaps.
 ### installation
 
 ```sh
-npm install --save broccoli-uglify-writer
+npm install --save broccoli-uglify-sourcemap
 ```
 
 ### usage
 
 ```js
-var uglify = require('broccoli-uglify-writer');
+var uglify = require('broccoli-uglify-sourcemap');
 
 // basic usage
 var uglified = uglify(input);


### PR DESCRIPTION
Title really says it all :smile: 

The readme currently says the package name ends in `-writer`. It actually ends in `-sourcemap`. This fixes that!