### PR TITLE
don’t minify files that already advertise as minified.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ UglifyWriter.prototype.write = function (readTree, outDir) {
 
       mkdirp.sync(path.dirname(outFile));
 
-      if (relativePath.slice(-3) === '.js' && !writer.excludes.match(relativePath)) {
+      if (relativePath.slice(-3) === '.js' && !writer.excludes.match(relativePath) && !/\.min\./.test(relativePath)) {
         writer.processFile(inFile, outFile, relativePath, outDir);
       } else if (relativePath.slice(-4) === '.map') {
         if (writer.excludes.match(relativePath.slice(relativePath.lenth - 4) + '.js')) {

--- a/test/expected/unminified/already.min.js
+++ b/test/expected/unminified/already.min.js
@@ -1,0 +1,5 @@
+function alreadyMin(xxxx, bbbb) {
+  // so don't touch it
+  //
+  return [xxxx, bbbb];
+}

--- a/test/fixtures/already.min.js
+++ b/test/fixtures/already.min.js
@@ -1,0 +1,5 @@
+function alreadyMin(xxxx, bbbb) {
+  // so don't touch it
+  //
+  return [xxxx, bbbb];
+}

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,7 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').in(result);
       expectFile('no-upstream-sourcemap.map').in(result);
       expectFile('something.css').in(result);
+      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -32,6 +33,7 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').withoutSourcemapURL().in(result);
       expectFile('no-upstream-sourcemap.map').notIn(result);
       expectFile('something.css').in(result);
+      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -47,6 +49,7 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').in(result);
       expectFile('no-upstream-sourcemap.map').in(result);
       expectFile('something.css').in(result);
+      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -60,6 +63,7 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').withSourcemapURL('/maps/no-upstream-sourcemap.map').in(result);
       expectFile('no-upstream-sourcemap.map').in(result, 'maps');
       expectFile('something.css').in(result);
+      expectFile('already.min.js').unminified().in(result);
     });
   });
 


### PR DESCRIPTION
just an idea, curious what others think.

We could also detect the content of the file seems sufficiently minified and skip it?