### PR TITLE
Revert "don’t minify files that already advertise as minified."

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ UglifyWriter.prototype.write = function (readTree, outDir) {
 
       mkdirp.sync(path.dirname(outFile));
 
-      if (relativePath.slice(-3) === '.js' && !writer.excludes.match(relativePath) && !/\.min\./.test(relativePath)) {
+      if (relativePath.slice(-3) === '.js' && !writer.excludes.match(relativePath)) {
         writer.processFile(inFile, outFile, relativePath, outDir);
       } else if (relativePath.slice(-4) === '.map') {
         if (writer.excludes.match(relativePath.slice(relativePath.lenth - 4) + '.js')) {

--- a/test/expected/unminified/already.min.js
+++ b/test/expected/unminified/already.min.js
@@ -1,5 +1,0 @@
-function alreadyMin(xxxx, bbbb) {
-  // so don't touch it
-  //
-  return [xxxx, bbbb];
-}

--- a/test/fixtures/already.min.js
+++ b/test/fixtures/already.min.js
@@ -1,5 +1,0 @@
-function alreadyMin(xxxx, bbbb) {
-  // so don't touch it
-  //
-  return [xxxx, bbbb];
-}

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,6 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').in(result);
       expectFile('no-upstream-sourcemap.map').in(result);
       expectFile('something.css').in(result);
-      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -33,7 +32,6 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').withoutSourcemapURL().in(result);
       expectFile('no-upstream-sourcemap.map').notIn(result);
       expectFile('something.css').in(result);
-      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -49,7 +47,6 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').in(result);
       expectFile('no-upstream-sourcemap.map').in(result);
       expectFile('something.css').in(result);
-      expectFile('already.min.js').unminified().in(result);
     });
   });
 
@@ -63,7 +60,6 @@ describe('broccoli-uglify-sourcemap', function() {
       expectFile('no-upstream-sourcemap.js').withSourcemapURL('/maps/no-upstream-sourcemap.map').in(result);
       expectFile('no-upstream-sourcemap.map').in(result, 'maps');
       expectFile('something.css').in(result);
-      expectFile('already.min.js').unminified().in(result);
     });
   });
 


### PR DESCRIPTION
This reverts commit 673f5f940744bb584e6017f01ef726c6d9eb7d91.

---

This change was breaking folks that used `.min` file extensions in their tree, then tried to run broccoli-uglify-sourcemap on them.

See:

* https://github.com/ember-cli/ember-cli/issues/5795
* https://github.com/emberjs/emberjs-build/pull/147