### PR TITLE
Limit uglify-js dependancy to < 2.7 for IE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mkdirp": "^0.5.0",
     "source-map-url": "^0.3.0",
     "symlink-or-copy": "^1.0.1",
-    "uglify-js": "^2.6.0",
+    "uglify-js": "~2.6.0",
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
UglifyJS 2.7.0 has dropped support for IE6 - 8 by default (although it can be reactivated via options). This change can (and did for me) unexpectedly break apps that use broccoli-uglify-sourcemap in IE 8.