### PR TITLE
Update uglify-js to ^2.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mkdirp": "^0.5.0",
     "source-map-url": "^0.3.0",
     "symlink-or-copy": "^1.0.1",
-    "uglify-js": "^2.6.0",
+    "uglify-js": "^2.7.0",
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The default maximum value for the sequences option in uglify changed
from unlimited to 2000 to fix mishoo/UglifyJS2#863 in 2.6.3 and also
changed from 2000 to 200, which fixes mishoo/UglifyJS2#1038, in 2.7.0.

The current version constraint is fine, but I think it's a good idea to begin forcing the version of uglify in use to include these fixes to help avoid surprises during and after minification.